### PR TITLE
fixed url regex not allowing www subdomain

### DIFF
--- a/src/components/ScoresDownloader.svelte
+++ b/src/components/ScoresDownloader.svelte
@@ -632,7 +632,7 @@
 			return;
 		}
 
-		const matches = profileUrl.match(/^(?:\s*https:\/\/scoresaber.com\/u\/(\d+))|(?:\s*https:\/\/www.beatleader.xyz\/u\/(\d+))/);
+		const matches = profileUrl.match(/https?:\/\/(?:www\.)?(?:scoresaber\.com|beatleader\.xyz)\/u\/(\d+)/);
 		if (!matches) {
 			error = 'Invalid URL';
 			return;


### PR DESCRIPTION
I didn't know why my BL profile wasn't working, found out the URL regex required to have the www subdomain